### PR TITLE
cc でビルドする実装に修正

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 
 [build-dependencies]
-cmake = "0.1.49"
+cc = { version = "1.0", features = ["parallel"] }
 
 [dev-dependencies]
 egui = "0.21.0"

--- a/build.rs
+++ b/build.rs
@@ -1,30 +1,33 @@
 fn main() {
-    // cmake による tinyusdz のビルド
-    let _ = cmake::Config::new("ffi/Externals/tinyusdz")
-        // .always_configure(false)
-        // .very_verbose(true)
-        .configure_arg("-DTINYUSDZ_BUILD_EXAMPLES=OFF")
-        .configure_arg("-DTINYUSDZ_BUILD_SHARED_LIBS=OFF")
-        .configure_arg("-DTINYUSDZ_BUILD_TESTS=OFF")
-        .configure_arg("-DTINYUSDZ_WITH_C_API=OFF")
-        .configure_arg("-DTINYUSDZ_WITH_TOOL_USDA_PARSER=OFF")
-        .configure_arg("-DTINYUSDZ_WITH_TOOL_USDC_PARSER=OFF")
-        .build_target("tinyusdz_static")
-        .build();
-    println!("cargo:rustc-link-search=native={}/ffi/Libraries", std::env::current_dir().unwrap().display());
-    println!("cargo:rustc-link-lib=static=tinyusdz_static");
-
-    // ffi ライブラリのビルド
-    let dst = cmake::Config::new("ffi")
-        // .always_configure(false)
-        // .very_verbose(true)
-        .build();
-    println!("cargo:rustc-link-search=native={}", dst.display());
-    println!("cargo:rustc-link-lib=static=usdffi");
-    
-    #[cfg(target_os = "macos")]
-    println!("cargo:rustc-link-lib=c++");
-
-    #[cfg(target_os = "linux")]
-    println!("cargo:rustc-link-lib=stdc++");
+    cc::Build::new()
+        .cpp(true)
+        .flag("-std=c++17")
+        .include("ffi/Externals/tinyusdz/src")
+        .files([
+            // ffi
+            "ffi/Sources/Libraries/usdffi/ffi.cpp",
+            // tinyusdz
+            "ffi/Externals/tinyusdz/src/ascii-parser-basetype.cc",
+            "ffi/Externals/tinyusdz/src/ascii-parser-timesamples-array.cc",
+            "ffi/Externals/tinyusdz/src/ascii-parser-timesamples.cc",
+            "ffi/Externals/tinyusdz/src/ascii-parser.cc",
+            "ffi/Externals/tinyusdz/src/path-util.cc",
+            "ffi/Externals/tinyusdz/src/pprinter.cc",
+            "ffi/Externals/tinyusdz/src/prim-composition.cc",
+            "ffi/Externals/tinyusdz/src/prim-reconstruct.cc",
+            "ffi/Externals/tinyusdz/src/prim-types.cc",
+            "ffi/Externals/tinyusdz/src/primvar.cc",
+            "ffi/Externals/tinyusdz/src/stage.cc",
+            "ffi/Externals/tinyusdz/src/str-util.cc",
+            "ffi/Externals/tinyusdz/src/tiny-format.cc",
+            "ffi/Externals/tinyusdz/src/tinyusdz.cc",
+            "ffi/Externals/tinyusdz/src/usda-reader.cc",
+            "ffi/Externals/tinyusdz/src/usdGeom.cc",
+            "ffi/Externals/tinyusdz/src/usdObj.cc",
+            "ffi/Externals/tinyusdz/src/usdShade.cc",
+            "ffi/Externals/tinyusdz/src/value-pprint.cc",
+            "ffi/Externals/tinyusdz/src/value-types.cc",
+            "ffi/Externals/tinyusdz/src/xform.cc",
+        ])
+        .compile("tinyusdz");
 }

--- a/ffi/Sources/Libraries/usdffi/ffi.cpp
+++ b/ffi/Sources/Libraries/usdffi/ffi.cpp
@@ -224,9 +224,10 @@ extern "C" bool Attribute_GetValuePpoint3f(const tinyusdz::Attribute *pInstance)
 //-----------------------------------------------------------------------------
 
 // Xform の API
-extern "C" bool Xform_GetLocalMatrix(const tinyusdz::Xform *pInstance, float *pArray, int count)
+extern "C" void Xform_GetLocalMatrix(const tinyusdz::Xform *pInstance,
+                                     float *pArray,
+                                     [[maybe_unused]] int count)
 {
-    tinyusdz::XformOp::OpType;
     const auto &matrix = pInstance->GetLocalMatrix();
     auto *pData        = &matrix->m[0][0];
     for (auto index = 0; index < 16; ++index) {


### PR DESCRIPTION
tinyusdz が依存を持たないので cc で良さそう。